### PR TITLE
feat: tailwind theme color(Button을 위함) 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,21 @@
 @import 'tailwindcss';
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+@theme {
+  --color-primary: #ff7f1c;
+  --color-primary-foreground: #ffffff;
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+  --color-primary-pressed: #e76500;
+  --color-primary-pressed-foreground: #ffbb87;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+  --color-primary-disabled: #ff7f1c30;
+  --color-primary-disabled-foreground: #ff7f1c;
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  --color-secondary: #e8e8e8;
+  --color-secondary-foreground: #555555;
+
+  --color-secondary-pressed: #d3d3d3;
+  --color-secondary-pressed-foreground: #777777;
+
+  --color-secondary-disabled: #f5f5f5;
+  --color-secondary-disabled-foreground: #cfcfcf;
 }


### PR DESCRIPTION
## 📋 요약
무엇을, 왜 변경했는지 간단히 설명해주세요.
Figma에 등록된 색상(primary, secondary)를 추가헀습니다. 
각 색상의 label 색상은 foreground로 등록했습니다. 

## 🔄 변경사항
어떤 영역을 수정했는지 체크해주세요:
- [x] 🎨 UI/컴포넌트
- [ ] 🔗 API/데이터
- [ ] 📄 페이지/라우팅
- [ ] 🎯 타입 정의
- [ ] ⚙️ 설정/빌드
- [ ] 📚 문서
- [ ] 🧪 테스트

## ✅ 품질 검사
PR 생성 전 아래 항목들을 확인해주세요:
- [x] `npm run ci` 통과 (lint + typecheck + build)
- [x] 로컬에서 정상 동작 확인 (`npm run dev`)
- [x] 타입 오류 없음
- [x] ESLint 경고 없음

## 📱 추가 테스트 (해당 시)
기능에 따라 필요한 경우 체크해주세요:
- [ ] 반응형 디자인 확인
- [ ] 다크모드 호환성 (향후)
- [ ] 접근성 기본 확인
- [ ] 브라우저 호환성 (Chrome, Safari, Firefox)

</details>

## 👀 리뷰 포인트
리뷰어가 특히 확인했으면 하는 부분:
- 코드 구조 및 가독성

<img width="313" height="490" alt="image" src="https://github.com/user-attachments/assets/cb171ec5-dcc8-4426-8022-6b5d02de2706" />

적용코드
```typescript
<>
      <div className='bg-primary text-primary-foreground flex h-20 w-3xs items-center justify-center'>
        기본
      </div>
      <div className='bg-primary-pressed text-primary-pressed-foreground flex h-20 w-3xs items-center justify-center'>
        기본 눌림
      </div>
      <div className='bg-primary-disabled text-primary-disabled-foreground flex h-20 w-3xs items-center justify-center'>
        기본 비활성
      </div>
      <div className='bg-secondary text-secondary-foreground flex h-20 w-3xs items-center justify-center'>
        흑백
      </div>
      <div className='bg-secondary-pressed text-secondary-pressed-foreground flex h-20 w-3xs items-center justify-center'>
        흑백 눌림
      </div>
      <div className='bg-secondary-disabled text-secondary-disabled-foreground flex h-20 w-3xs items-center justify-center'>
        흑백 비활성
      </div>
    </>
```

## 🔗 관련 이슈
관련 이슈나 PR이 있다면 링크해주세요:
- Closes #
- Related to #
