### PR TITLE
feat: BottomCTA 컴포넌트 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "dongjeop-front",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "next": "15.4.6",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2316,6 +2318,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -5852,6 +5863,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "ci": "npm run format:check && npm run lint && npm run typecheck && npm run build"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "15.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/ui/bottom-cta.tsx
+++ b/src/components/ui/bottom-cta.tsx
@@ -1,0 +1,112 @@
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+
+import { cn } from '@/lib/utils';
+import { ClassName } from '@/types/common';
+
+interface BottomCTAProps extends ClassName, PropsWithChildren {}
+
+interface BottomCTASingleProps extends ClassName, BottomCTAProps {}
+
+interface BottomCTADoubleProps extends ClassName {
+  ratio: '1:1' | '1:2';
+  leftButtonProps: BottomCTAButtonProps;
+  rightButtonProps: BottomCTAButtonProps;
+}
+
+interface BottomCTAButtonProps extends ClassName, PropsWithChildren {
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  variant: 'primary' | 'secondary';
+  disabled?: boolean;
+  label?: string;
+  onClick?: VoidFunction;
+}
+
+const BOTTOM_CTA_CLASSNAME = 'fixed right-0 bottom-0 left-0';
+// TODO: 너비 확정 시 적용 필요
+const BOTTOM_CTA_INNER_CLASSNAME = 'mx-auto h-14 w-full';
+
+const BottomCTA = ({ children, className }: BottomCTAProps) => {
+  return (
+    <footer className={BOTTOM_CTA_CLASSNAME}>
+      <div className={cn(BOTTOM_CTA_INNER_CLASSNAME, className)}>
+        {children}
+      </div>
+    </footer>
+  );
+};
+
+const Single = ({ children, className }: BottomCTASingleProps) => {
+  return (
+    <footer className={BOTTOM_CTA_CLASSNAME}>
+      <div className={cn(BOTTOM_CTA_INNER_CLASSNAME, className)}>
+        {children}
+      </div>
+    </footer>
+  );
+};
+
+const Double = ({
+  ratio,
+  className,
+  leftButtonProps,
+  rightButtonProps,
+}: BottomCTADoubleProps) => {
+  return (
+    <footer className={BOTTOM_CTA_CLASSNAME}>
+      <div className={cn(BOTTOM_CTA_INNER_CLASSNAME, className)}>
+        <Button
+          {...leftButtonProps}
+          className={cn(
+            ratio === '1:1' ? 'w-1/2' : 'w-1/3',
+            leftButtonProps.className
+          )}
+        />
+        <Button
+          {...rightButtonProps}
+          className={cn(
+            ratio === '1:1' ? 'w-1/2' : 'w-2/3',
+            rightButtonProps.className
+          )}
+        />
+      </div>
+    </footer>
+  );
+};
+
+const BUTTON_VARIANT_CLASSNAME = {
+  primary:
+    'bg-primary text-primary-foreground active:bg-primary-pressed active:text-primary-pressed-foreground disabled:bg-primary-disabled disabled:text-primary-disabled-foreground',
+  secondary:
+    'bg-secondary text-secondary-foreground active:bg-secondary-pressed active:text-secondary-pressed-foreground disabled:bg-secondary-disabled disabled:text-secondary-disabled-foreground',
+} as const;
+
+const Button = ({
+  children,
+  label,
+  variant,
+  className,
+  disabled,
+  type = 'button',
+  onClick,
+}: BottomCTAButtonProps) => {
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      className={cn(
+        BUTTON_VARIANT_CLASSNAME[variant],
+        'text-18-semibold h-14 w-full rounded-none transition-all duration-100 ease-out',
+        className
+      )}
+      onClick={onClick}
+    >
+      {label ? label : children}
+    </button>
+  );
+};
+
+BottomCTA.Single = Single;
+BottomCTA.Button = Button;
+BottomCTA.Double = Double;
+
+export default BottomCTA;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,12 @@ import { extendTailwindMerge } from 'tailwind-merge';
 export const extendTwMerge = extendTailwindMerge({
   extend: {
     classGroups: {
+      'font-size': [
+        'text-26-bold',
+        'text-18-semibold',
+        'text-18-medium',
+        'text-16-regular',
+      ],
       'text-color': [
         'text-primary',
         'text-primary-foreground',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import { ClassValue } from 'clsx';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+export const extendTwMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      'text-color': [
+        'text-primary',
+        'text-primary-foreground',
+        'text-primary-pressed',
+        'text-primary-pressed-foreground',
+        'text-primary-disabled',
+        'text-primary-disabled-foreground',
+        'text-secondary',
+        'text-secondary-foreground',
+        'text-secondary-pressed',
+        'text-secondary-pressed-foreground',
+        'text-secondary-disabled',
+        'text-secondary-disabled-foreground',
+      ],
+      'bg-color': [
+        'bg-primary',
+        'bg-primary-pressed',
+        'bg-primary-disabled',
+        'bg-secondary',
+        'bg-secondary-pressed',
+        'bg-secondary-disabled',
+      ],
+    },
+  },
+});
+
+export const cn = (...inputs: ClassValue[]) => {
+  return extendTwMerge(clsx(inputs));
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,3 @@
+export interface ClassName {
+  className?: string;
+}


### PR DESCRIPTION
## 📋 요약
무엇을, 왜 변경했는지 간단히 설명해주세요.
하단 버튼 컴포넌트 `BottomCTA`를 제작했습니다. 
<img width="358" height="282" alt="스크린샷 2025-09-22 오후 8 38 49" src="https://github.com/user-attachments/assets/edd5540d-13e5-4dae-ae9c-126ac78a3f03" />
<img width="359" height="258" alt="스크린샷 2025-09-22 오후 8 38 36" src="https://github.com/user-attachments/assets/c76e249c-7df0-47fb-962c-98dcae77d584" />
<img width="357" height="186" alt="스크린샷 2025-09-22 오후 8 38 00" src="https://github.com/user-attachments/assets/11a58b1c-b0c5-473a-8e35-6f226124554b" />


## 🔄 변경사항
어떤 영역을 수정했는지 체크해주세요:
- [x] 🎨 UI/컴포넌트
- [ ] 🔗 API/데이터
- [ ] 📄 페이지/라우팅
- [ ] 🎯 타입 정의
- [ ] ⚙️ 설정/빌드
- [ ] 📚 문서
- [ ] 🧪 테스트

## ✅ 품질 검사
PR 생성 전 아래 항목들을 확인해주세요:
- [ ] `npm run ci` 통과 (lint + typecheck + build)
- [ ] 로컬에서 정상 동작 확인 (`npm run dev`)
- [ ] 타입 오류 없음
- [ ] ESLint 경고 없음

## 📱 추가 테스트 (해당 시)
기능에 따라 필요한 경우 체크해주세요:
- [ ] 반응형 디자인 확인
- [ ] 다크모드 호환성 (향후)
- [ ] 접근성 기본 확인
- [ ] 브라우저 호환성 (Chrome, Safari, Firefox)

</details>
- 하단 버튼은 크게 Single과 Double로 나뉩니다. 그래서 컴파운드 패턴을 통해 Single과 Double을 선택할 수 있도록 했습니다. 
- BottomCTA의 경우 Default가 Single이 되도록 설정했습니다. 
- Double의 경우 ratio를 통해 두 버튼의 비율을 조절하고 leftButtonProps 와 rightButtonProps를 통해 버튼 정보를 전달할 수 있게 설정했습니다. 
- BottomCTA를 위한 버튼 컴포넌트를 제작했습니다. 

## 👀 리뷰 포인트
리뷰어가 특히 확인했으면 하는 부분:
- 코드 구조 및 가독성
컴파운드 패턴 구조를 처음 써봤는데, 어떤 지 의견 많이많이X1000 남겨주시면 감사하겠습니다. 

## 🔗 관련 이슈
관련 이슈나 PR이 있다면 링크해주세요:
- Closes #
- Related to #
