### PR TITLE
fix: 정답셋 선택지 디자인 반영

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,7 @@
   --color-muted: #727272;
 
   --color-border-default: #00000010;
+  --color-border-blue: #3491ff;
 
   --color-info: #0052c8;
 

--- a/src/app/label/[imageKey]/_components/label-step/label-step2.tsx
+++ b/src/app/label/[imageKey]/_components/label-step/label-step2.tsx
@@ -29,11 +29,27 @@ type LabelStep2OptionValue =
 const NOT_SURE_VALUE = 'not_sure';
 
 const LABEL_STEP_2_OPTIONS: labelOption<LabelStep2OptionValue>[] = [
-  { title: '낮은 이동식 의자', value: 'has_movable_chair' },
-  { title: '높은 이동식 의자', value: 'has_high_chair' },
-  { title: '좌식 의자', value: 'has_floor_chair' },
-  { title: '고정식 의자', value: 'has_fixed_chair' },
-  { title: '잘 모르겠어요', value: NOT_SURE_VALUE },
+  {
+    title: '일반 의자',
+    subtitle: '이동이 가능한, 일반적인 높이의 의자',
+    value: 'has_movable_chair',
+  },
+  {
+    title: '높은 의자',
+    subtitle: '주로 높은 바 테이블과 사용되는 의자',
+    value: 'has_high_chair',
+  },
+  {
+    title: '좌식',
+    subtitle: '바닥에 앉는 형태의 의자 또는 방석',
+    value: 'has_floor_chair',
+  },
+  {
+    title: '붙박이/소파 의자',
+    subtitle: '밀어도 움직이지 않는 의자',
+    value: 'has_fixed_chair',
+  },
+  { title: '잘 모르겠어요', subtitle: '', value: NOT_SURE_VALUE },
 ];
 
 export const LabelStep2 = ({
@@ -108,11 +124,12 @@ export const LabelStep2 = ({
         className='pb-20'
         labelingOptions={
           <ButtonList className='w-full'>
-            {LABEL_STEP_2_OPTIONS.map(({ title, value }) => (
+            {LABEL_STEP_2_OPTIONS.map(({ title, subtitle, value }) => (
               <ButtonList.Item
                 key={title}
                 disabled={isPending}
                 title={title}
+                subTitle={subtitle}
                 selected={selectedValue.includes(value)}
                 onClick={() => handleSelect(value)}
               />

--- a/src/components/ui/button-list.tsx
+++ b/src/components/ui/button-list.tsx
@@ -78,7 +78,7 @@ const Item = ({
         aria-selected={selected}
         className={cn(
           'flex w-full cursor-pointer items-center justify-between rounded-xl border p-2.5 pr-5 transition-all duration-75 ease-out active:scale-[0.98]',
-          selected ? 'border-[#3491FF]' : 'border-border-default',
+          selected ? 'border-border-blue' : 'border-border-default',
           className
         )}
       >

--- a/src/components/ui/button-list.tsx
+++ b/src/components/ui/button-list.tsx
@@ -99,8 +99,8 @@ const Item = ({
         {selected && (
           <Image
             src='/icons/check-blue.svg'
-            width={24}
-            height={24}
+            width={20}
+            height={20}
             alt=''
           />
         )}


### PR DESCRIPTION
## 📋 요약

<!-- 무엇을, 왜 변경했는지 간단히 설명해주세요. -->

- 체크 아이콘 사이즈 조정 (24 → 20)
- border 색상 토큰(`--color-border-blue`) 추가 및 적용
- 의자 형태 선택지에 subtitle 추가, title 문구 변경 사항 반영
- 화면 너비가 344px인 Galaxy Z Fold 5에서는 레이아웃 깨지나, 360px 미만은 엣지케이스라고 생각되어 별도 대응은 하지 않으려 합니다! (그래도 되겠죠 ....?)

| 너비 360px | 너비 344px |
|:--:|:--:|
| <img width="580" height="746" alt="image" src="https://github.com/user-attachments/assets/7933d9a7-63d6-4cf8-8c76-fbcd520298a3" /> | <img width="692" height="733" alt="image" src="https://github.com/user-attachments/assets/cba2f912-a53c-44c0-bb67-618a20c6d4e6" /> |

## 🔄 변경사항

<!-- 어떤 영역을 수정했는지 체크해주세요: -->

- [x] 🎨 UI/컴포넌트
- [ ] 🔗 API/데이터
- [ ] 📄 페이지/라우팅
- [ ] 🎯 타입 정의
- [ ] ⚙️ 설정/빌드
- [ ] 📚 문서
- [ ] 🧪 테스트

## ✅ 품질 검사

<!-- PR 생성 전 아래 항목들을 확인해주세요: -->

- [x] `npm run ci` 통과 (lint + typecheck + build)
- [x] 로컬에서 정상 동작 확인 (`npm run dev`)
- [x] 타입 오류 없음
- [x] ESLint 경고 없음

## 📱 추가 테스트 (해당 시)

<!-- 기능에 따라 필요한 경우 체크해주세요: -->

- [ ] 반응형 디자인 확인
- [ ] 다크모드 호환성 (향후)
- [ ] 접근성 기본 확인
- [ ] 브라우저 호환성 (Chrome, Safari, Firefox)

</details>

## 👀 리뷰 포인트
리뷰어가 특히 확인했으면 하는 부분:
- 코드 구조 및 가독성
- 타입 정의의 적절성
- 컴포넌트 재사용성
- 성능 고려사항 (필요시)

## 🔗 관련 이슈
관련 이슈나 PR이 있다면 링크해주세요:
- Closes #
- Related to #
